### PR TITLE
Fix bug when pressing auto-stop after maunal-interval

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -73,22 +73,19 @@ function colourBoxChange () {
 
 const colourBtnGp = document.getElementById("colour-btn-group");
 colourBtnGp.addEventListener("click", (event) => {
+    // clear interval is done first to avoid creating overlapping intervals
+    // it duplicates the would-be implementation for for manual stop button
+    // hence case "manual-stop" is omitted in the switch board
+    clearInterval(colourInterval);
     switch(event.target.id) {
         case "manual-interval":
-            colourInterval = setInterval(() => {
-                colourBoxChange();
-            }, 500);
-            break;
-        case "manual-stop":
-            clearInterval(colourInterval);
+            colourInterval = setInterval(colourBoxChange, 500);
             break;
         case "auto-stop":
             setTimeout(() => {
                 clearInterval(colourInterval);
             }, 5000);
-            colourInterval = setInterval(() => {
-                colourBoxChange();
-            }, 500);
+            colourInterval = setInterval(colourBoxChange, 500);
             break;
     }
 })


### PR DESCRIPTION
I think I figured out why the bug happens. It's because overlapped intervals are allowed.
The fix the bug/prevent creating overlapped intervals, clear interval is executed as first thing when any button is clicked.

Leave in comments plus a bit of code refactor.
